### PR TITLE
Changes made to remove addUri() method from queues. Now only addUris(…

### DIFF
--- a/squirrel.api/src/main/java/org/dice_research/squirrel/frontier/Frontier.java
+++ b/squirrel.api/src/main/java/org/dice_research/squirrel/frontier/Frontier.java
@@ -31,17 +31,7 @@ public interface Frontier extends Closeable {
     List<CrawleableUri> getNextUris();
 
     /**
-     * Add this URIs to the {@link Frontier}s internal queue if the internal
-     * rules of the {@link Frontier} allow it.
-     *
-     * @param uri
-     *            the URI that should be added to the {@link Frontier}
-     */
-    void addNewUri(CrawleableUri uri);
-
-    /**
-     * Adds the given list of URIs to the {@link Frontier}. It is like calling
-     * {@link #addNewUri(CrawleableUri)} with every single URI.
+     * Adds the given list of URIs to the {@link Frontier}.
      *
      * @param newUris
      *            the URIs that should be added to the {@link Frontier}

--- a/squirrel.api/src/main/java/org/dice_research/squirrel/queue/AbstractGroupingQueue.java
+++ b/squirrel.api/src/main/java/org/dice_research/squirrel/queue/AbstractGroupingQueue.java
@@ -41,22 +41,6 @@ public abstract class AbstractGroupingQueue<T> implements BlockingQueue<T> {
     }
 
     @Override
-    public void addUri(CrawleableUri uri) {
-        synchronized (this) {
-            addUri(uri, groupByOperator.retrieveKey(uri));
-        }
-    }
-
-    /**
-     * Adds the given URI with they given group key to the queue.
-     *
-     * @param uri      the URI that should be added to the queue
-     * @param groupKey the group key which should be used to identify the group this URI
-     *                 belongs to
-     */
-    protected abstract void addUri(CrawleableUri uri, T groupKey);
-
-    @Override
     public List<CrawleableUri> getNextUris() {
         synchronized (this) {
             T key;
@@ -139,9 +123,14 @@ public abstract class AbstractGroupingQueue<T> implements BlockingQueue<T> {
     @Override
     public void addUris(List<CrawleableUri> uris) {
         synchronized (this) {
-            addKeywiseUris(groupByOperator.groupByKey(uris));
+            addUris(groupByOperator.groupByKey(uris));
         }
     }
 
-    protected abstract void addKeywiseUris(Map<T, List<CrawleableUri>> uris);
+    /**
+     * adds URIs key-wise
+     *
+     * @param uris     URIs categorized according to the key
+     */
+    protected abstract void addUris(Map<T, List<CrawleableUri>> uris);
 }

--- a/squirrel.api/src/main/java/org/dice_research/squirrel/queue/InMemoryQueue.java
+++ b/squirrel.api/src/main/java/org/dice_research/squirrel/queue/InMemoryQueue.java
@@ -18,8 +18,7 @@ public class InMemoryQueue extends AbstractIpAddressBasedQueue implements Compar
         queue = new TreeMap<InetAddress, List<CrawleableUri>>(this);
     }
 
-    @Override
-    protected void addUri(CrawleableUri uri, InetAddress address) {
+    private void addUri(CrawleableUri uri, InetAddress address) {
         if (queue.containsKey(address)) {
             queue.get(address).add(uri);
         } else {
@@ -93,6 +92,11 @@ public class InMemoryQueue extends AbstractIpAddressBasedQueue implements Compar
 	}
 
     @Override
-    protected void addKeywiseUris(Map<InetAddress, List<CrawleableUri>> uris) {
+    protected void addUris(Map<InetAddress, List<CrawleableUri>> ipwiseUris) {
+        for(Map.Entry<InetAddress, List<CrawleableUri>> entry : ipwiseUris.entrySet()) {
+            for(CrawleableUri uri : entry.getValue()) {
+                addUri(uri, entry.getKey());
+            }
+        }
     }
 }

--- a/squirrel.api/src/main/java/org/dice_research/squirrel/queue/UriQueue.java
+++ b/squirrel.api/src/main/java/org/dice_research/squirrel/queue/UriQueue.java
@@ -13,15 +13,6 @@ import org.dice_research.squirrel.data.uri.CrawleableUri;
 public interface UriQueue {
 
     /**
-     * Adds the given {@link CrawleableUri} instance to the queue.
-     *
-     * @param uri
-     *            the {@link CrawleableUri} instance that should be added to the
-     *            queue.
-     */
-    public void addUri(CrawleableUri uri);
-
-    /**
      * Returns the next chunk of URIs that should be crawled or null. Note that
      * this method removes the URIs from the queue.
      *

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainBasedQueue.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainBasedQueue.java
@@ -16,7 +16,6 @@ import org.dice_research.squirrel.data.uri.CrawleableUri;
 import org.dice_research.squirrel.data.uri.serialize.Serializer;
 import org.dice_research.squirrel.data.uri.serialize.java.SnappyJavaUriSerializer;
 import org.dice_research.squirrel.queue.AbstractDomainBasedQueue;
-import org.dice_research.squirrel.queue.scorebasedfilter.IUriKeywiseFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,14 +38,11 @@ public class MongoDBDomainBasedQueue extends AbstractDomainBasedQueue {
     private final String DB_NAME = "squirrel";
     private final String COLLECTION_QUEUE = "queue";
     protected final String COLLECTION_URIS = "uris";
-    private IUriKeywiseFilter uriKeywiseFilter;
     @Deprecated
     private final String DEFAULT_TYPE = "default";
     private static final boolean PERSIST = System.getenv("QUEUE_FILTER_PERSIST") == null ? false
         : Boolean.parseBoolean(System.getenv("QUEUE_FILTER_PERSIST"));
     public static final String URI_DOMAIN = "domain";
-    private float criticalScore = .2f;
-    private int minNumberOfUrisToCheck = 5;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBDomainBasedQueue.class);
 

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainBasedQueue.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainBasedQueue.java
@@ -99,12 +99,6 @@ public class MongoDBDomainBasedQueue extends AbstractDomainBasedQueue {
         client.close();
     }
 
-    @Override
-    protected void addUri(CrawleableUri uri, String domain) {
-        addDomain(domain);
-        addCrawleableUri(uri, domain);
-    }
-
     protected void addCrawleableUri(CrawleableUri uri, String domain) {
         try {
             Document uriDoc = getUriDocument(uri, domain);
@@ -250,11 +244,12 @@ public class MongoDBDomainBasedQueue extends AbstractDomainBasedQueue {
     }
 
     @Override
-    protected void addKeywiseUris(Map<String, List<CrawleableUri>> uris) {
-        Map<CrawleableUri, Float> uriMap = uriKeywiseFilter.filterUrisKeywise(uris, minNumberOfUrisToCheck, criticalScore);
-        for(Map.Entry<CrawleableUri, Float> entry : uriMap.entrySet()) {
-            addDomain(entry.getKey().getUri().getHost());
-            addCrawleableUri(entry.getKey(), entry.getKey().getUri().getHost());
+    protected void addUris(Map<String, List<CrawleableUri>> domainwiswUris) {
+        for(Map.Entry<String, List<CrawleableUri>> entry : domainwiswUris.entrySet()) {
+            addDomain(entry.getKey());
+            for(CrawleableUri uri : entry.getValue()) {
+                addCrawleableUri(uri, entry.getKey());
+            }
         }
     }
 

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainScoreBasedQueue.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainScoreBasedQueue.java
@@ -18,9 +18,9 @@ import org.dice_research.squirrel.data.uri.CrawleableUri;
 import org.dice_research.squirrel.data.uri.serialize.Serializer;
 import org.dice_research.squirrel.data.uri.serialize.java.SnappyJavaUriSerializer;
 import org.dice_research.squirrel.queue.scorebasedfilter.IUriKeywiseFilter;
-import org.dice_research.squirrel.queue.scorebasedfilter.UriKeywiseFilter;
+import org.dice_research.squirrel.queue.scorebasedfilter.ScoreBasedScoreBasedUriKeywiseFilter;
 import org.dice_research.squirrel.queue.scorecalculator.IUriScoreCalculator;
-import org.dice_research.squirrel.queue.scorecalculator.UriScoreCalculator;
+import org.dice_research.squirrel.queue.scorecalculator.UriDuplicityScoreCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,22 +52,22 @@ public class MongoDBDomainScoreBasedQueue extends MongoDBDomainBasedQueue {
      */
     public MongoDBDomainScoreBasedQueue(String hostName, Integer port, boolean includeDepth, QueryExecutionFactory queryExecFactory) {
         super(hostName, port, new SnappyJavaUriSerializer(), includeDepth);
-        this.uriScoreCalculator = new UriScoreCalculator(queryExecFactory);
-        this.uriKeywiseFilter = new UriKeywiseFilter(uriScoreCalculator);
+        this.uriScoreCalculator = new UriDuplicityScoreCalculator(queryExecFactory);
+        this.uriKeywiseFilter = new ScoreBasedScoreBasedUriKeywiseFilter(uriScoreCalculator);
     }
 
     public MongoDBDomainScoreBasedQueue(String hostName, Integer port, Serializer serializer, boolean includeDepth, String sparqlEndpointUrl, String username, String password) {
         super(hostName, port, serializer, includeDepth);
         QueryExecutionFactory qef = getQueryExecutionFactory(sparqlEndpointUrl, username, password);
-        this.uriScoreCalculator = new UriScoreCalculator(qef);
-        this.uriKeywiseFilter = new UriKeywiseFilter(uriScoreCalculator);
+        this.uriScoreCalculator = new UriDuplicityScoreCalculator(qef);
+        this.uriKeywiseFilter = new ScoreBasedScoreBasedUriKeywiseFilter(uriScoreCalculator);
     }
 
-    public MongoDBDomainScoreBasedQueue(String hostName, Integer port, Serializer serializer, boolean includeDepth, String sparqlEndpointUrl, String username, String password, UriScoreCalculator uriScoreCalculator, UriKeywiseFilter uriKeywiseFilter) {
+    public MongoDBDomainScoreBasedQueue(String hostName, Integer port, Serializer serializer, boolean includeDepth, String sparqlEndpointUrl, String username, String password, UriDuplicityScoreCalculator uriScoreCalculator, ScoreBasedScoreBasedUriKeywiseFilter scoreBasedUriKeywiseFilter) {
         super(hostName, port, serializer, includeDepth);
         QueryExecutionFactory qef = getQueryExecutionFactory(sparqlEndpointUrl, username, password);
         this.uriScoreCalculator = uriScoreCalculator;
-        this.uriKeywiseFilter = uriKeywiseFilter;
+        this.uriKeywiseFilter = scoreBasedUriKeywiseFilter;
     }
 
     private QueryExecutionFactory getQueryExecutionFactory(String sparqlEndpointUrl, String username, String password) {

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainScoreBasedQueue.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainScoreBasedQueue.java
@@ -41,8 +41,6 @@ public class MongoDBDomainScoreBasedQueue extends MongoDBDomainBasedQueue {
     private static final boolean PERSIST = System.getenv("QUEUE_FILTER_PERSIST") == null ? false
         : Boolean.parseBoolean(System.getenv("QUEUE_FILTER_PERSIST"));
     public static final String URI_DOMAIN = "domain";
-    private float criticalScore = .2f;
-    private int minNumberOfUrisToCheck = 5;
     private IUriKeywiseFilter uriKeywiseFilter;
     private IUriScoreCalculator uriScoreCalculator;
 
@@ -63,6 +61,13 @@ public class MongoDBDomainScoreBasedQueue extends MongoDBDomainBasedQueue {
         QueryExecutionFactory qef = getQueryExecutionFactory(sparqlEndpointUrl, username, password);
         this.uriScoreCalculator = new UriScoreCalculator(qef);
         this.uriKeywiseFilter = new UriKeywiseFilter(uriScoreCalculator);
+    }
+
+    public MongoDBDomainScoreBasedQueue(String hostName, Integer port, Serializer serializer, boolean includeDepth, String sparqlEndpointUrl, String username, String password, UriScoreCalculator uriScoreCalculator, UriKeywiseFilter uriKeywiseFilter) {
+        super(hostName, port, serializer, includeDepth);
+        QueryExecutionFactory qef = getQueryExecutionFactory(sparqlEndpointUrl, username, password);
+        this.uriScoreCalculator = uriScoreCalculator;
+        this.uriKeywiseFilter = uriKeywiseFilter;
     }
 
     private QueryExecutionFactory getQueryExecutionFactory(String sparqlEndpointUrl, String username, String password) {
@@ -103,13 +108,6 @@ public class MongoDBDomainScoreBasedQueue extends MongoDBDomainBasedQueue {
         return qef;
     }
 
-    @Override
-    protected void addUri(CrawleableUri uri, String domain) {
-        addDomain(domain);
-        // default score taken as 1
-        addCrawleableUri(uri, domain, 1);
-    }
-
     protected void addCrawleableUri(CrawleableUri uri, String domain, float score) {
         try {
             Document uriDoc = getUriDocument(uri, domain);
@@ -148,29 +146,14 @@ public class MongoDBDomainScoreBasedQueue extends MongoDBDomainBasedQueue {
         return listUris;
     }
 
-
     @Override
-    protected void addKeywiseUris(Map<String, List<CrawleableUri>> uris) {
-        Map<CrawleableUri, Float> uriMap = uriKeywiseFilter.filterUrisKeywise(uris, minNumberOfUrisToCheck, criticalScore);
-        for(Map.Entry<CrawleableUri, Float> entry : uriMap.entrySet()) {
-            addDomain(entry.getKey().getUri().getHost());
-            addCrawleableUri(entry.getKey(), entry.getKey().getUri().getHost(), entry.getValue());
+    protected void addUris(Map<String, List<CrawleableUri>> domainwiswUris) {
+        Map<String, List<CrawleableUri>> uriMap = uriKeywiseFilter.filterUrisKeywise(domainwiswUris);
+        for(Map.Entry<String, List<CrawleableUri>> entry : uriMap.entrySet()) {
+            addDomain(entry.getKey());
+            for(CrawleableUri uri:entry.getValue()) {
+                addCrawleableUri(uri, entry.getKey(), (float)uri.getData(Constants.URI_SCORE));
+            }
         }
-    }
-
-    public float getCriticalScore() {
-        return criticalScore;
-    }
-
-    public void setCriticalScore(float criticalScore) {
-        this.criticalScore = criticalScore;
-    }
-
-    public int getMinNumberOfUrisToCheck() {
-        return minNumberOfUrisToCheck;
-    }
-
-    public void setMinNumberOfUrisToCheck(int minNumberOfUrisToCheck) {
-        this.minNumberOfUrisToCheck = minNumberOfUrisToCheck;
     }
 }

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpBasedQueue.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpBasedQueue.java
@@ -1,22 +1,5 @@
 package org.dice_research.squirrel.queue.ipbased;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.*;
-
-import org.bson.Document;
-import org.bson.types.Binary;
-import org.dice_research.squirrel.Constants;
-import org.dice_research.squirrel.configurator.MongoConfiguration;
-import org.dice_research.squirrel.data.uri.CrawleableUri;
-import org.dice_research.squirrel.data.uri.serialize.Serializer;
-import org.dice_research.squirrel.data.uri.serialize.java.SnappyJavaUriSerializer;
-import org.dice_research.squirrel.queue.AbstractIpAddressBasedQueue;
-import org.dice_research.squirrel.queue.scorebasedfilter.IUriKeywiseFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoWriteException;
@@ -25,6 +8,21 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Indexes;
+import org.bson.Document;
+import org.bson.types.Binary;
+import org.dice_research.squirrel.Constants;
+import org.dice_research.squirrel.configurator.MongoConfiguration;
+import org.dice_research.squirrel.data.uri.CrawleableUri;
+import org.dice_research.squirrel.data.uri.serialize.Serializer;
+import org.dice_research.squirrel.data.uri.serialize.java.SnappyJavaUriSerializer;
+import org.dice_research.squirrel.queue.AbstractIpAddressBasedQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
 
 /**
  * IpBasedQueue implementation for use with MongoDB
@@ -39,14 +37,11 @@ public class MongoDBIpBasedQueue extends AbstractIpAddressBasedQueue {
     private final String DB_NAME = "squirrel";
     private final String COLLECTION_QUEUE = "queue";
     protected final String COLLECTION_URIS = "uris";
-    private IUriKeywiseFilter uriKeywiseFilter;
     @Deprecated
     private final String DEFAULT_TYPE = "default";
     private static final boolean PERSIST = System.getenv("QUEUE_FILTER_PERSIST") == null ? false
         : Boolean.parseBoolean(System.getenv("QUEUE_FILTER_PERSIST"));
     public static final String URI_IP_ADRESS = "ipAddress";
-    private float criticalScore = .2f;
-    private int minNumberOfUrisToCheck = 5;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBIpBasedQueue.class);
 
@@ -125,11 +120,6 @@ public class MongoDBIpBasedQueue extends AbstractIpAddressBasedQueue {
             }
         }
         return false;
-    }
-
-    private void addUri(CrawleableUri uri, InetAddress address) {
-        addIp(address);
-        addCrawleableUri(uri);
     }
 
     @Override

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpBasedQueue.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpBasedQueue.java
@@ -127,8 +127,7 @@ public class MongoDBIpBasedQueue extends AbstractIpAddressBasedQueue {
         return false;
     }
 
-    @Override
-    protected void addUri(CrawleableUri uri, InetAddress address) {
+    private void addUri(CrawleableUri uri, InetAddress address) {
         addIp(address);
         addCrawleableUri(uri);
     }
@@ -298,11 +297,12 @@ public class MongoDBIpBasedQueue extends AbstractIpAddressBasedQueue {
     }
 
     @Override
-    protected void addKeywiseUris(Map<InetAddress, List<CrawleableUri>> uris) {
-        Map<CrawleableUri, Float> uriMap = uriKeywiseFilter.filterUrisKeywise(uris, minNumberOfUrisToCheck, criticalScore);
-        for(Map.Entry<CrawleableUri, Float> entry : uriMap.entrySet()) {
-            addIp(entry.getKey().getIpAddress());
-            addCrawleableUri(entry.getKey());
+    protected void addUris(Map<InetAddress, List<CrawleableUri>> ipwiseUris) {
+        for(Map.Entry<InetAddress, List<CrawleableUri>> entry : ipwiseUris.entrySet()) {
+            addIp(entry.getKey());
+            for(CrawleableUri uri : entry.getValue()) {
+                addCrawleableUri(uri);
+            }
         }
     }
 

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpScoreBasedQueue.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpScoreBasedQueue.java
@@ -18,9 +18,9 @@ import org.dice_research.squirrel.data.uri.CrawleableUri;
 import org.dice_research.squirrel.data.uri.serialize.Serializer;
 import org.dice_research.squirrel.data.uri.serialize.java.SnappyJavaUriSerializer;
 import org.dice_research.squirrel.queue.scorebasedfilter.IUriKeywiseFilter;
-import org.dice_research.squirrel.queue.scorebasedfilter.UriKeywiseFilter;
+import org.dice_research.squirrel.queue.scorebasedfilter.ScoreBasedScoreBasedUriKeywiseFilter;
 import org.dice_research.squirrel.queue.scorecalculator.IUriScoreCalculator;
-import org.dice_research.squirrel.queue.scorecalculator.UriScoreCalculator;
+import org.dice_research.squirrel.queue.scorecalculator.UriDuplicityScoreCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,22 +50,22 @@ public class MongoDBIpScoreBasedQueue extends MongoDBIpBasedQueue {
      */
     public MongoDBIpScoreBasedQueue(String hostName, Integer port, boolean includeDepth, QueryExecutionFactory queryExecFactory) {
         super(hostName, port, new SnappyJavaUriSerializer(), includeDepth);
-        this.uriScoreCalculator = new UriScoreCalculator(queryExecFactory);
-        this.uriKeywiseFilter = new UriKeywiseFilter(uriScoreCalculator);
+        this.uriScoreCalculator = new UriDuplicityScoreCalculator(queryExecFactory);
+        this.uriKeywiseFilter = new ScoreBasedScoreBasedUriKeywiseFilter(uriScoreCalculator);
     }
 
     public MongoDBIpScoreBasedQueue(String hostName, Integer port, Serializer serializer, boolean includeDepth, String sparqlEndpointUrl, String username, String password) {
         super(hostName, port, serializer, includeDepth);
         QueryExecutionFactory qef = getQueryExecutionFactory(sparqlEndpointUrl, username, password);
-        this.uriScoreCalculator = new UriScoreCalculator(qef);
-        this.uriKeywiseFilter = new UriKeywiseFilter(uriScoreCalculator);
+        this.uriScoreCalculator = new UriDuplicityScoreCalculator(qef);
+        this.uriKeywiseFilter = new ScoreBasedScoreBasedUriKeywiseFilter(uriScoreCalculator);
     }
 
-    public MongoDBIpScoreBasedQueue(String hostName, Integer port, Serializer serializer, boolean includeDepth, String sparqlEndpointUrl, String username, String password, UriScoreCalculator uriScoreCalculator, UriKeywiseFilter uriKeywiseFilter) {
+    public MongoDBIpScoreBasedQueue(String hostName, Integer port, Serializer serializer, boolean includeDepth, String sparqlEndpointUrl, String username, String password, UriDuplicityScoreCalculator uriScoreCalculator, ScoreBasedScoreBasedUriKeywiseFilter scoreBasedUriKeywiseFilter) {
         super(hostName, port, serializer, includeDepth);
         QueryExecutionFactory qef = getQueryExecutionFactory(sparqlEndpointUrl, username, password);
         this.uriScoreCalculator = uriScoreCalculator;
-        this.uriKeywiseFilter = uriKeywiseFilter;
+        this.uriKeywiseFilter = scoreBasedUriKeywiseFilter;
     }
 
     private QueryExecutionFactory getQueryExecutionFactory(String sparqlEndpointUrl, String username, String password) {

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/IUriKeywiseFilter.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/IUriKeywiseFilter.java
@@ -6,12 +6,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Interface for filtering URIs based on score
+ * Interface for filtering URIs.
  */
 public interface IUriKeywiseFilter<T> {
 
     /**
-     * This method returns the {@link CrawleableUri}s to be added to the queue after filtering out the ones based on their score
+     * This method returns the {@link CrawleableUri}s to be added to the queue.
      *
      * @param keyWiseUris map of based on key {@link CrawleableUri}s to be filtered
      * @return {@link Map} of filtered {@link CrawleableUri}s to be added to the queue with their scores

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/IUriKeywiseFilter.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/IUriKeywiseFilter.java
@@ -6,17 +6,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Interface for filtering URIs based on duplicity score
+ * Interface for filtering URIs based on score
  */
 public interface IUriKeywiseFilter<T> {
 
     /**
      * This method returns the {@link CrawleableUri}s to be added to the queue after filtering out the ones based on their score
      *
-     * @param keyWiseUris            map of based on key {@link CrawleableUri}s to be filtered
-     * @param minNumberOfUrisToCheck minimum number of {@link CrawleableUri}s to be checked for their score before filtering
-     * @param criticalScore          the critical score to check for filtering
-     * @return {@link Map} of {@link CrawleableUri}s to be added to the queue with their scores
+     * @param keyWiseUris map of based on key {@link CrawleableUri}s to be filtered
+     * @return {@link Map} of filtered {@link CrawleableUri}s to be added to the queue with their scores
      */
-    Map<CrawleableUri, Float> filterUrisKeywise(Map<T, List<CrawleableUri>> keyWiseUris, int minNumberOfUrisToCheck, float criticalScore);
+    Map<T, List<CrawleableUri>> filterUrisKeywise(Map<T, List<CrawleableUri>> keyWiseUris);
 }

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/ScoreBasedScoreBasedUriKeywiseFilter.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/ScoreBasedScoreBasedUriKeywiseFilter.java
@@ -12,24 +12,33 @@ import java.util.Map;
 /**
  * This class filters the {@link CrawleableUri}s to be added to the queue based on the score.
  */
-public class UriKeywiseFilter<T> implements IUriKeywiseFilter {
+public class ScoreBasedScoreBasedUriKeywiseFilter<T> implements IUriKeywiseFilter {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UriKeywiseFilter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScoreBasedScoreBasedUriKeywiseFilter.class);
     private IUriScoreCalculator scoreCalculator;
     private float criticalScore = .2f;      //  default value
     private int minNumberOfUrisToCheck = 5;      //  default value
 
 
-    public UriKeywiseFilter(IUriScoreCalculator scoreCalculator) {
+    public ScoreBasedScoreBasedUriKeywiseFilter(IUriScoreCalculator scoreCalculator) {
         this.scoreCalculator = scoreCalculator;
     }
 
-    public UriKeywiseFilter(IUriScoreCalculator scoreCalculator, float criticalScore, int minNumberOfUrisToCheck) {
+    public ScoreBasedScoreBasedUriKeywiseFilter(IUriScoreCalculator scoreCalculator, float criticalScore, int minNumberOfUrisToCheck) {
         this.scoreCalculator = scoreCalculator;
         this.criticalScore = criticalScore;
         this.minNumberOfUrisToCheck = minNumberOfUrisToCheck;
     }
 
+    /**
+     * This method returns the {@link CrawleableUri}s to be added to the queue.
+     * The UriKeywiseFilter{@link #minNumberOfUrisToCheck} URis of each key are tested to see if their scores
+     * are below UriKeywiseFilter{@link #criticalScore}. If all are below UriKeywiseFilter{@link #criticalScore},
+     * the Uris of that key are filtered out.
+     *
+     * @param keyWiseUris map of based on key {@link CrawleableUri}s to be filtered
+     * @return {@link Map} of filtered {@link CrawleableUri}s to be added to the queue with their scores
+     */
     @Override
     public Map<T, List<CrawleableUri>> filterUrisKeywise(Map keyWiseUris) {
         Map<T, List<CrawleableUri>> filteredUriMap = new HashMap<>();

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/UriKeywiseFilter.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorebasedfilter/UriKeywiseFilter.java
@@ -1,11 +1,10 @@
 package org.dice_research.squirrel.queue.scorebasedfilter;
 
+import org.dice_research.squirrel.Constants;
 import org.dice_research.squirrel.data.uri.CrawleableUri;
 import org.dice_research.squirrel.queue.scorecalculator.IUriScoreCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,34 +12,61 @@ import java.util.Map;
 /**
  * This class filters the {@link CrawleableUri}s to be added to the queue based on the score.
  */
-public class UriKeywiseFilter implements IUriKeywiseFilter {
+public class UriKeywiseFilter<T> implements IUriKeywiseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UriKeywiseFilter.class);
     private IUriScoreCalculator scoreCalculator;
+    private float criticalScore = .2f;      //  default value
+    private int minNumberOfUrisToCheck = 5;      //  default value
+
 
     public UriKeywiseFilter(IUriScoreCalculator scoreCalculator) {
         this.scoreCalculator = scoreCalculator;
     }
 
+    public UriKeywiseFilter(IUriScoreCalculator scoreCalculator, float criticalScore, int minNumberOfUrisToCheck) {
+        this.scoreCalculator = scoreCalculator;
+        this.criticalScore = criticalScore;
+        this.minNumberOfUrisToCheck = minNumberOfUrisToCheck;
+    }
+
     @Override
-    public Map<CrawleableUri, Float> filterUrisKeywise(Map keyWiseUris, int minNumberOfUrisToCheck, float criticalScore) {
-        Collection<List<CrawleableUri>> uriLists = keyWiseUris.values();
-        Map<CrawleableUri, Float> filteredUriMap = new HashMap<>();
-        for (List<CrawleableUri> uriList : uriLists) {
+    public Map<T, List<CrawleableUri>> filterUrisKeywise(Map keyWiseUris) {
+        Map<T, List<CrawleableUri>> filteredUriMap = new HashMap<>();
+        for (Map.Entry<T, List<CrawleableUri>> entry:((Map<T, List<CrawleableUri>>)keyWiseUris).entrySet()) {
             boolean scoresBelowCritical = true;
+            List<CrawleableUri> uriList = entry.getValue();
             for (int i = 0; i < (minNumberOfUrisToCheck < uriList.size() ? minNumberOfUrisToCheck : uriList.size()); i++) {
                 float score = scoreCalculator.getURIScore(uriList.get(i));
                 if (score > criticalScore) {
                     scoresBelowCritical = false;
+                    break;
                 }
             }
             if (!scoresBelowCritical) {
-                for (CrawleableUri uri : uriList) {
-                    filteredUriMap.put(uri, scoreCalculator.getURIScore(uri));
+                for(CrawleableUri uri:uriList) {
+                    uri.addData(Constants.URI_SCORE, scoreCalculator.getURIScore(uri));
                 }
+                filteredUriMap.put(entry.getKey(), entry.getValue());
             }
         }
         return filteredUriMap;
+    }
+
+    public float getCriticalScore() {
+        return criticalScore;
+    }
+
+    public void setCriticalScore(float criticalScore) {
+        this.criticalScore = criticalScore;
+    }
+
+    public int getMinNumberOfUrisToCheck() {
+        return minNumberOfUrisToCheck;
+    }
+
+    public void setMinNumberOfUrisToCheck(int minNumberOfUrisToCheck) {
+        this.minNumberOfUrisToCheck = minNumberOfUrisToCheck;
     }
 }
 

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorecalculator/IUriScoreCalculator.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorecalculator/IUriScoreCalculator.java
@@ -3,12 +3,12 @@ package org.dice_research.squirrel.queue.scorecalculator;
 import org.dice_research.squirrel.data.uri.CrawleableUri;
 
 /**
- *  Interface for getting duplicity score of a Uri.
+ *  Interface for getting score of a Uri.
  */
 public interface IUriScoreCalculator {
 
     /**
-     * Returns the score based on specific score calculation implementation
+     * Returns a score for the given URI based on the implemented scoring function.
      *
      * @return {@link CrawleableUri} score
      */

--- a/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorecalculator/UriDuplicityScoreCalculator.java
+++ b/squirrel.frontier/src/main/java/org/dice_research/squirrel/queue/scorecalculator/UriDuplicityScoreCalculator.java
@@ -14,27 +14,27 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.sparql.core.DatasetDescription;
 import org.dice_research.squirrel.data.uri.CrawleableUri;
-import org.dice_research.squirrel.queue.scorebasedfilter.UriKeywiseFilter;
+import org.dice_research.squirrel.queue.scorebasedfilter.ScoreBasedScoreBasedUriKeywiseFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 
 /**
- * Interface for getting duplicity score of a Uri.
- * The duplicity score is calculated for a {@link CrawleableUri} as 1 / (number of times the Uri occurs as a subject in graphs
+ * Interface for getting score of a Uri.
+ * The score is calculated for a {@link CrawleableUri} as 1 / (number of times the Uri occurs as a subject in graphs
  */
-public class UriScoreCalculator implements IUriScoreCalculator {
+public class UriDuplicityScoreCalculator implements IUriScoreCalculator {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UriKeywiseFilter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScoreBasedScoreBasedUriKeywiseFilter.class);
 
     protected QueryExecutionFactory queryExecFactory = null;
 
-    public UriScoreCalculator(QueryExecutionFactory qe) {
+    public UriDuplicityScoreCalculator(QueryExecutionFactory qe) {
         this.queryExecFactory = qe;
     }
 
-    public UriScoreCalculator(String sparqlEndpointUrl, String username, String password) {
+    public UriDuplicityScoreCalculator(String sparqlEndpointUrl, String username, String password) {
         if (username != null && password != null) {
             // Create the factory with the credentials
             final Credentials credentials = new UsernamePasswordCredentials(username, password);

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/MongoDBBasedTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/MongoDBBasedTest.java
@@ -10,10 +10,10 @@ import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
 public class MongoDBBasedTest {
-	
+
 	public static final String DB_HOST_NAME = "localhost";
     public static final int DB_PORT = 58027;
-    
+
     protected static  MongoClient client;
 	protected static  MongoDatabase mongoDB;
 
@@ -33,7 +33,7 @@ public class MongoDBBasedTest {
         while ((s = stdError.readLine()) != null) {
             System.out.println(s);
         }
-        
+
         client = new MongoClient(DB_HOST_NAME,DB_PORT);
 
     }

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/frontier/impl/FrontierImplTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/frontier/impl/FrontierImplTest.java
@@ -166,6 +166,7 @@ public class FrontierImplTest {
     public void tearDown() throws Exception {
         filter.purge();
         queue.purge();
+        uris.clear();
         String rethinkDockerStopCommand = "docker stop squirrel-test-frontierimpl";
         Process p = Runtime.getRuntime().exec(rethinkDockerStopCommand);
         p.waitFor();

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/frontier/impl/FrontierImplTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/frontier/impl/FrontierImplTest.java
@@ -71,7 +71,9 @@ public class FrontierImplTest {
     @Test
     public void getNextUris() throws Exception {
 
-        queue.addUri(uris.get(1));
+        List<CrawleableUri> urisToAdd = new ArrayList<>();
+        urisToAdd.add(uris.get(1));
+        queue.addUris(urisToAdd);
 
         //  queue.addCrawleableUri(uris.get(1));
         List<CrawleableUri> nextUris = frontier.getNextUris();
@@ -92,17 +94,6 @@ public class FrontierImplTest {
         assertion.add(cuf.create(new URI("http://dbpedia.org/resource/Moscow"), InetAddress.getByName("194.109.129.58"),
             UriType.DEREFERENCEABLE));
         assertEquals("Should be the same as uris array", assertion, nextUris);
-    }
-
-    @Test
-    public void addNewUri() throws Exception {
-        CrawleableUri uri_1 = cuf.create(new URI("http://dbpedia.org/resource/Tom_Lazarus"), null, UriType.UNKNOWN);
-        frontier.addNewUri(uri_1);
-        List<CrawleableUri> nextUris = frontier.getNextUris();
-        List<CrawleableUri> assertion = new ArrayList<>();
-        assertion.add(cuf.create(new URI("http://dbpedia.org/resource/Tom_Lazarus"),
-            InetAddress.getByName("194.109.129.58"), UriType.DEREFERENCEABLE));
-        assertEquals(assertion, nextUris);
     }
 
     @Test

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/IpAddressBasedQueueIpBlockingTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/IpAddressBasedQueueIpBlockingTest.java
@@ -3,6 +3,7 @@ package org.dice_research.squirrel.queue;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -22,14 +23,14 @@ import org.slf4j.LoggerFactory;
  * thread adds URIs to the queue until the second thread has finished its work.
  * Every added URI has the same type and one of two IPs.
  * </p>
- * 
+ *
  * <p>
  * The second thread takes a single chunk, thus, blocks one of the two IPs and
  * sets this IP in the third thread. After that the second thread sleeps for a
  * long time. At the end of this sleeping period, it informs the other two
  * threads about its termination, marks the ip as accessible and terminates.
  * </p>
- * 
+ *
  * <p>
  * The third thread requests new chunks from the queue (with a lower frequency
  * than the first thread is adding them) and checks whether it gets chunks
@@ -37,12 +38,12 @@ import org.slf4j.LoggerFactory;
  * finished, this thread makes sure that it gets at least one time URIs of the
  * IP that has been blocked by the second thread.
  * </p>
- * 
+ *
  * @author Michael R&ouml;der (roeder@informatik.uni-leipzig.de)
  *
  */
 public class IpAddressBasedQueueIpBlockingTest {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(IpAddressBasedQueueIpBlockingTest.class);
 
     private static final long DELAY_BETWEEN_URI_GENERATIONS = 10;
@@ -85,7 +86,7 @@ public class IpAddressBasedQueueIpBlockingTest {
     /**
      * Simple threads that adds URIs with a delay until its run flag is set to
      * false.
-     * 
+     *
      * @author Michael R&ouml;der (roeder@informatik.uni-leipzig.de)
      *
      */
@@ -112,7 +113,9 @@ public class IpAddressBasedQueueIpBlockingTest {
                 while (run) {
                     CrawleableUri uri = generateNextUri();
                     LOGGER.debug("Adding URI {}", uri);
-                    queue.addUri(uri);
+                    List<CrawleableUri> urisToAdd = new ArrayList<>();
+                    urisToAdd.add(uri);
+                    queue.addUris(urisToAdd);
                     try {
                         Thread.sleep(DELAY_BETWEEN_URI_GENERATIONS);
                     } catch (InterruptedException e) {
@@ -150,7 +153,7 @@ public class IpAddressBasedQueueIpBlockingTest {
      * This thread waits a short time, requests a chunk of URIs and waits for a
      * long time. After that it stops the {@link UriAdder} and informs the
      * {@link RegularUriConsumer} about its termination.
-     * 
+     *
      * @author Michael R&ouml;der (roeder@informatik.uni-leipzig.de)
      *
      */
@@ -206,14 +209,14 @@ public class IpAddressBasedQueueIpBlockingTest {
      * does not get a URI with the IP blocked by the other
      * {@link LongDelayUriConsumer}.
      * </p>
-     * 
+     *
      * <p>
      * After the {@link LongDelayUriConsumer} is dead, this thread waits for a
      * short time. After that it requests three more chunks. It makes sure that
      * at least one of the first two chunks contains the IP that has been
      * blocked by the other thread and that the third chunk is null.
      * </p>
-     * 
+     *
      * @author Michael R&ouml;der (roeder@informatik.uni-leipzig.de)
      *
      */

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/IpAddressBasedQueueIpPackagingTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/IpAddressBasedQueueIpPackagingTest.java
@@ -24,7 +24,7 @@ import org.junit.runners.Parameterized.Parameters;
  * chunks should have the same IP address and the same {@link UriType}. For
  * every IP UriType combination there shouldn't be more than one single chunk.
  * </p>
- * 
+ *
  * @author Michael R&ouml;der (roeder@informatik.uni-leipzig.de)
  *
  */
@@ -109,11 +109,7 @@ public class IpAddressBasedQueueIpPackagingTest {
     @Test
     public void test() throws Exception {
         BlockingQueue<InetAddress> queue = new InMemoryQueue();
-
-        for (int i = 0; i < uris.length; ++i) {
-            queue.addUri(uris[i]);
-        }
-
+        queue.addUris(Arrays.asList(uris));
         int chunkId;
         BitSet chunksFound = new BitSet(expectedChunks.length);
         List<CrawleableUri> chunk = queue.getNextUris();

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainQueueTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainQueueTest.java
@@ -77,9 +77,7 @@ public class MongoDBDomainQueueTest extends MongoDBBasedTest {
         mongodbQueue.open();
         mongodbQueue.purge();
         assertEquals(0, mongodbQueue.length());
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
         assertEquals(3, mongodbQueue.length());
         mongodbQueue.purge();
         assertEquals(0, mongodbQueue.length());
@@ -90,9 +88,13 @@ public class MongoDBDomainQueueTest extends MongoDBBasedTest {
     public void addCrawleableUri() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        mongodbQueue.addUri(uris.get(1));
+        List<CrawleableUri> urisToAdd = new ArrayList<>();
+        urisToAdd.add(uris.get(1));
+        mongodbQueue.addUris(urisToAdd);
         assertEquals(1, mongodbQueue.length());
-        mongodbQueue.addUri(uris.get(2));
+        urisToAdd.clear();
+        urisToAdd.add(uris.get(2));
+        mongodbQueue.addUris(urisToAdd);
         assertEquals(1, mongodbQueue.length());
         mongodbQueue.close();
     }
@@ -101,9 +103,7 @@ public class MongoDBDomainQueueTest extends MongoDBBasedTest {
     public void getIterator() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
         Iterator<String> iter = mongodbQueue.getGroupIterator();
         List<String> domains = new ArrayList<String>();
         while (iter.hasNext()) {
@@ -118,9 +118,7 @@ public class MongoDBDomainQueueTest extends MongoDBBasedTest {
     public void getUris() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
 
         List<CrawleableUri> listUris = mongodbQueue.getNextUris();
         Iterator<String> iter = mongodbQueue.getGroupIterator();
@@ -142,11 +140,15 @@ public class MongoDBDomainQueueTest extends MongoDBBasedTest {
     public void deleteUris() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        mongodbQueue.addUri(uris.get(1));
+        List<CrawleableUri> urisToAdd = new ArrayList<>();
+        urisToAdd.add(uris.get(1));
+        mongodbQueue.addUris(urisToAdd);
         List<CrawleableUri> retrievedUris = mongodbQueue.getNextUris();
         assertEquals(1, retrievedUris.size());
         assertTrue(uris.get(1).equals(retrievedUris.get(0)));
-        mongodbQueue.addUri(uris.get(2));
+        urisToAdd.clear();
+        urisToAdd.add(uris.get(2));
+        mongodbQueue.addUris(urisToAdd);
         // The retrieval should fail
         assertNull(mongodbQueue.getNextUris());
         // Give back the first URI

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainScoreBasedQueueTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/domainbased/MongoDBDomainScoreBasedQueueTest.java
@@ -87,38 +87,10 @@ public class MongoDBDomainScoreBasedQueueTest extends MongoDBBasedTest {
     }
 
     @Test
-    public void addCrawleableUriWithScore() throws Exception {
-        mongodbQueue.open();
-        mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
-        assertEquals(3, mongodbQueue.length());
-        List<CrawleableUri> listUris = mongodbQueue.getNextUris();
-        assertEquals(1, listUris.size());
-        List<CrawleableUri> listUris2 = mongodbQueue.getNextUris();
-        assertEquals(4, listUris2.size());
-        Assert.assertTrue(listUris2.contains(uris.get(1)));                 // "http://dbpedia.org/resource/New_York_City"
-        Assert.assertTrue(listUris2.contains(uris.get(2)));                 // "http://dbpedia.org/resource/Moscow"
-        Assert.assertTrue(listUris2.contains(uris.get(3)));                 // "http://dbpedia.org/resource/Berlin"
-        Assert.assertTrue(listUris2.contains(uris.get(4)));                 // "http://dbpedia.org/resource/Bangalore"
-        List<CrawleableUri> listUris3 = mongodbQueue.getNextUris();
-        assertEquals(1, listUris3.size());
-        List<CrawleableUri> listUris4 = mongodbQueue.getNextUris();
-        assertEquals(null, listUris4);
-        mongodbQueue.purge();
-        mongodbQueue.close();
-    }
-
-    @Test
     public void getUris() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
-
-        List<CrawleableUri> listUris = mongodbQueue.getNextUris();
+        mongodbQueue.addUris(uris);
         Iterator<String> iter = mongodbQueue.getGroupIterator();
         int count = 0;
         while (iter.hasNext()) {
@@ -129,13 +101,12 @@ public class MongoDBDomainScoreBasedQueueTest extends MongoDBBasedTest {
                 ++count;
             }
         }
-
         assertEquals(uris.size(), count);
         mongodbQueue.close();
     }
 
     @Test
-    public void testAddKeywiseUris() throws URISyntaxException {
+    public void testAddUris() throws URISyntaxException {
         mongodbQueue.open();
         mongodbQueue.purge();
         Map<String, List<CrawleableUri>> keyWiseUris = new HashMap<>();
@@ -145,7 +116,7 @@ public class MongoDBDomainScoreBasedQueueTest extends MongoDBBasedTest {
         dbpediaUris.add(uri1);
         dbpediaUris.add(uri2);
         keyWiseUris.put("dbpedia.org", dbpediaUris);
-        mongodbQueue.addKeywiseUris(keyWiseUris);
+        mongodbQueue.addUris(keyWiseUris);
         List<CrawleableUri> mongoDBUris = mongodbQueue.getUris("dbpedia.org");
         Assert.assertTrue(mongoDBUris.contains(uri1));
         Assert.assertTrue(mongoDBUris.contains(uri2));

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpBasedQueueTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpBasedQueueTest.java
@@ -70,7 +70,7 @@ public class MongoDBIpBasedQueueTest  extends MongoDBBasedTest{
         mongodbQueue.open();
         mongodbQueue.purge();
         assertFalse(mongodbQueue.containsIpAddress(uris.get(0).getIpAddress()));
-        mongodbQueue.addUri(uris.get(0));
+        mongodbQueue.addUris(uris);
         assertTrue(mongodbQueue.containsIpAddress(uris.get(0).getIpAddress()));
         mongodbQueue.close();
     }
@@ -80,9 +80,7 @@ public class MongoDBIpBasedQueueTest  extends MongoDBBasedTest{
         mongodbQueue.open();
         mongodbQueue.purge();
         assertEquals(0, mongodbQueue.length());
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
         assertEquals(3, mongodbQueue.length());
         mongodbQueue.purge();
         assertEquals(0, mongodbQueue.length());
@@ -93,9 +91,13 @@ public class MongoDBIpBasedQueueTest  extends MongoDBBasedTest{
     public void addCrawleableUri() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        mongodbQueue.addUri(uris.get(1));
+        List<CrawleableUri> urisToAdd = new ArrayList<>();
+        urisToAdd.add(uris.get(1));
+        mongodbQueue.addUris(urisToAdd);
         assertEquals(1, mongodbQueue.length());
-        mongodbQueue.addUri(uris.get(2));
+        urisToAdd.clear();
+        urisToAdd.add(uris.get(2));
+        mongodbQueue.addUris(urisToAdd);
         assertEquals(1, mongodbQueue.length());
         mongodbQueue.close();
     }
@@ -104,9 +106,7 @@ public class MongoDBIpBasedQueueTest  extends MongoDBBasedTest{
     public void addToQueue() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
         assertEquals(3, mongodbQueue.length());
         mongodbQueue.close();
     }
@@ -116,9 +116,7 @@ public class MongoDBIpBasedQueueTest  extends MongoDBBasedTest{
     public void getIterator() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
         Iterator<InetAddress> iter = mongodbQueue.getGroupIterator();
         int ipCount = 0;
         while (iter.hasNext()) {
@@ -132,9 +130,7 @@ public class MongoDBIpBasedQueueTest  extends MongoDBBasedTest{
     public void getUris() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
         Iterator<InetAddress> iter = mongodbQueue.getGroupIterator();
         int count = 0;
         while (iter.hasNext()) {
@@ -152,11 +148,15 @@ public class MongoDBIpBasedQueueTest  extends MongoDBBasedTest{
     public void deleteUris() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        mongodbQueue.addUri(uris.get(1));
+        List<CrawleableUri> urisToAdd = new ArrayList<>();
+        urisToAdd.add(uris.get(1));
+        mongodbQueue.addUris(urisToAdd);
         List<CrawleableUri> retrievedUris = mongodbQueue.getNextUris();
         assertEquals(1, retrievedUris.size());
         assertTrue(uris.get(1).equals(retrievedUris.get(0)));
-        mongodbQueue.addUri(uris.get(2));
+        urisToAdd.clear();
+        urisToAdd.add(uris.get(2));
+        mongodbQueue.addUris(urisToAdd);
         // The retrieval should fail
         assertNull(mongodbQueue.getNextUris());
         // Give back the first URI

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpScoreBasedQueueTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/ipbased/MongoDBIpScoreBasedQueueTest.java
@@ -75,75 +75,46 @@ public class MongoDBIpScoreBasedQueueTest extends MongoDBBasedTest{
         Node o = NodeFactory.createURI("http://dbpedia.org/doesntMatter");
         DatasetGraph graph = dataset.asDatasetGraph();
 
-        for(int i = 0; i <= 5; i++) {
+        for(int i = 0; i < 5; i++) {
             Node p = NodeFactory.createURI(otherUri + i);
             graph.add(g, s1, p, o); // <http://dbpedia.org/resource/New_York_City>
         }
-        for(int i = 0; i <= 10; i++) {
+        for(int i = 0; i < 10; i++) {
             Node p = NodeFactory.createURI(otherUri + i);
             graph.add(g, s2, p, o); // <http://dbpedia.org/resource/Berlin>
         }
-        for(int i = 0; i <= 8; i++) {
+        for(int i = 0; i < 8; i++) {
             Node p = NodeFactory.createURI(otherUri + i);
             graph.add(g, s3, p, o); // <http://dbpedia.org/resource/Bangalore>
         }
-        for(int i = 0; i <= 4; i++) {
+        for(int i = 0; i < 4; i++) {
             Node p = NodeFactory.createURI(otherUri + i);
             graph.add(g, s4, p, o); // <http://dbpedia.org/resource/Moscow>
         }
-
-
         return new QueryExecutionFactoryDataset(dataset);
-    }
-
-
-    @Test
-    public void addCrawleableUriWithScore() throws Exception {
-        mongodbQueue.open();
-        mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
-        assertEquals(3, mongodbQueue.length());
-        List<CrawleableUri> listUris = mongodbQueue.getNextUris();
-        assertEquals(1, listUris.size());
-        List<CrawleableUri> listUris2 = mongodbQueue.getNextUris();
-        assertEquals(4, listUris2.size());
-        Assert.assertTrue(listUris2.contains(uris.get(1)));                 // "http://dbpedia.org/resource/New_York_City"
-        Assert.assertTrue(listUris2.contains(uris.get(2)));                 // "http://dbpedia.org/resource/Moscow"
-        Assert.assertTrue(listUris2.contains(uris.get(3)));                 // "http://dbpedia.org/resource/Berlin"
-        Assert.assertTrue(listUris2.contains(uris.get(4)));                 // "http://dbpedia.org/resource/Bangalore"
-        List<CrawleableUri> listUris3 = mongodbQueue.getNextUris();
-        assertEquals(1, listUris3.size());
-        List<CrawleableUri> listUris4 = mongodbQueue.getNextUris();
-        assertEquals(null, listUris4);
-        mongodbQueue.purge();
-        mongodbQueue.close();
     }
 
     @Test
     public void getUris() throws Exception {
         mongodbQueue.open();
         mongodbQueue.purge();
-        for (CrawleableUri uri : uris) {
-            mongodbQueue.addUri(uri);
-        }
+        mongodbQueue.addUris(uris);
         Iterator<InetAddress> iter = mongodbQueue.getGroupIterator();
         int count = 0;
         while (iter.hasNext()) {
-            List<CrawleableUri> uriList = mongodbQueue.getUris(iter.next());
+            InetAddress ip = iter.next();
+            List<CrawleableUri> uriList = mongodbQueue.getUris(ip);
             for (CrawleableUri uri : uriList) {
                 assertTrue(uris.contains(uri));
                 ++count;
             }
         }
-        assertEquals(uris.size(), count);
+        assertEquals(6, count);
         mongodbQueue.close();
     }
 
-
     @Test
-    public void testAddKeywiseUris() throws URISyntaxException, UnknownHostException {
+    public void testAddUris() throws URISyntaxException, UnknownHostException {
         mongodbQueue.open();
         mongodbQueue.purge();
         Map<InetAddress, List<CrawleableUri>> keyWiseUris = new HashMap<>();
@@ -153,7 +124,7 @@ public class MongoDBIpScoreBasedQueueTest extends MongoDBBasedTest{
         dbpediaUris.add(uri1);
         dbpediaUris.add(uri2);
         keyWiseUris.put(InetAddress.getByName("dbpedia.org"), dbpediaUris);
-        mongodbQueue.addKeywiseUris(keyWiseUris);
+        mongodbQueue.addUris(keyWiseUris);
         List<CrawleableUri> mongoDBUris = mongodbQueue.getUris(InetAddress.getByName("dbpedia.org"));
         Assert.assertTrue(mongoDBUris.contains(uri1));
         Assert.assertTrue(mongoDBUris.contains(uri2));

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/scorebasedfilter/ScoreBasedUriKeywiseFilterTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/scorebasedfilter/ScoreBasedUriKeywiseFilterTest.java
@@ -2,7 +2,7 @@ package org.dice_research.squirrel.queue.scorebasedfilter;
 
 import org.dice_research.squirrel.MongoDBScoreBasedTest;
 import org.dice_research.squirrel.data.uri.CrawleableUri;
-import org.dice_research.squirrel.queue.scorecalculator.UriScoreCalculator;
+import org.dice_research.squirrel.queue.scorecalculator.UriDuplicityScoreCalculator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -13,12 +13,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class UriKeywiseFilterTest extends MongoDBScoreBasedTest {
+public class ScoreBasedUriKeywiseFilterTest extends MongoDBScoreBasedTest {
 
     @Test
     public void testFilterUrisKeywise() throws URISyntaxException {
-        UriScoreCalculator scoreCalculator = new UriScoreCalculator(queryExecFactory);
-        UriKeywiseFilter uriKeywiseFilter = new UriKeywiseFilter(scoreCalculator, .2f, 3);
+        UriDuplicityScoreCalculator scoreCalculator = new UriDuplicityScoreCalculator(queryExecFactory);
+        ScoreBasedScoreBasedUriKeywiseFilter scoreBasedUriKeywiseFilter = new ScoreBasedScoreBasedUriKeywiseFilter(scoreCalculator, .2f, 3);
 
         Map<String, List<CrawleableUri>> keyWiseUris = new HashMap<>();
         List<CrawleableUri> dbpediaUris = new ArrayList<>();
@@ -41,7 +41,7 @@ public class UriKeywiseFilterTest extends MongoDBScoreBasedTest {
         lonelyPlanetUris.add(uri8);
         keyWiseUris.put("www.lonelyplanet.com", lonelyPlanetUris);
         keyWiseUris.put("dbpedia.org", dbpediaUris);
-        Map<String, List<CrawleableUri>> filteredUris = uriKeywiseFilter.filterUrisKeywise(keyWiseUris);
+        Map<String, List<CrawleableUri>> filteredUris = scoreBasedUriKeywiseFilter.filterUrisKeywise(keyWiseUris);
         Assert.assertEquals(1, filteredUris.size());
         Assert.assertTrue(filteredUris.containsKey("www.lonelyplanet.com"));
         Assert.assertEquals(4, filteredUris.get("www.lonelyplanet.com").size());

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/scorebasedfilter/UriKeywiseFilterTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/scorebasedfilter/UriKeywiseFilterTest.java
@@ -18,7 +18,7 @@ public class UriKeywiseFilterTest extends MongoDBScoreBasedTest {
     @Test
     public void testFilterUrisKeywise() throws URISyntaxException {
         UriScoreCalculator scoreCalculator = new UriScoreCalculator(queryExecFactory);
-        UriKeywiseFilter uriKeywiseFilter = new UriKeywiseFilter(scoreCalculator);
+        UriKeywiseFilter uriKeywiseFilter = new UriKeywiseFilter(scoreCalculator, .2f, 3);
 
         Map<String, List<CrawleableUri>> keyWiseUris = new HashMap<>();
         List<CrawleableUri> dbpediaUris = new ArrayList<>();
@@ -30,11 +30,6 @@ public class UriKeywiseFilterTest extends MongoDBScoreBasedTest {
         dbpediaUris.add(uri2);
         dbpediaUris.add(uri3);
         dbpediaUris.add(uri4);
-        keyWiseUris.put("dbpedia.org", dbpediaUris);
-
-        Assert.assertEquals(4, uriKeywiseFilter.filterUrisKeywise(keyWiseUris, 2, .001f).size());
-        Assert.assertEquals(0, uriKeywiseFilter.filterUrisKeywise(keyWiseUris, 2, .8f).size());
-
         CrawleableUri uri5 = new CrawleableUri(new URI("https://www.lonelyplanet.com/germany/paderborn"));
         CrawleableUri uri6 = new CrawleableUri(new URI("https://www.lonelyplanet.com/germany/north-rhine-westphalia/dortmund"));
         CrawleableUri uri7 = new CrawleableUri(new URI("https://www.lonelyplanet.com/england/london"));
@@ -45,12 +40,14 @@ public class UriKeywiseFilterTest extends MongoDBScoreBasedTest {
         lonelyPlanetUris.add(uri7);
         lonelyPlanetUris.add(uri8);
         keyWiseUris.put("www.lonelyplanet.com", lonelyPlanetUris);
-        Map<CrawleableUri, Float> filteredUris = uriKeywiseFilter.filterUrisKeywise(keyWiseUris, 2, .2f);
-
-        Assert.assertEquals(4, filteredUris.size());
-        Assert.assertTrue(filteredUris.containsKey(uri5));
-        Assert.assertTrue(filteredUris.containsKey(uri6));
-        Assert.assertTrue(filteredUris.containsKey(uri7));
-        Assert.assertTrue(filteredUris.containsKey(uri8));
+        keyWiseUris.put("dbpedia.org", dbpediaUris);
+        Map<String, List<CrawleableUri>> filteredUris = uriKeywiseFilter.filterUrisKeywise(keyWiseUris);
+        Assert.assertEquals(1, filteredUris.size());
+        Assert.assertTrue(filteredUris.containsKey("www.lonelyplanet.com"));
+        Assert.assertEquals(4, filteredUris.get("www.lonelyplanet.com").size());
+        Assert.assertTrue(filteredUris.get("www.lonelyplanet.com").contains(uri5));
+        Assert.assertTrue(filteredUris.get("www.lonelyplanet.com").contains(uri6));
+        Assert.assertTrue(filteredUris.get("www.lonelyplanet.com").contains(uri7));
+        Assert.assertTrue(filteredUris.get("www.lonelyplanet.com").contains(uri8));
     }
 }

--- a/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/uriscorecalculator/UriScoreCalculatorTest.java
+++ b/squirrel.frontier/src/test/java/org/dice_research/squirrel/queue/uriscorecalculator/UriScoreCalculatorTest.java
@@ -2,7 +2,7 @@ package org.dice_research.squirrel.queue.uriscorecalculator;
 
 import org.dice_research.squirrel.MongoDBScoreBasedTest;
 import org.dice_research.squirrel.data.uri.CrawleableUri;
-import org.dice_research.squirrel.queue.scorecalculator.UriScoreCalculator;
+import org.dice_research.squirrel.queue.scorecalculator.UriDuplicityScoreCalculator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -13,7 +13,7 @@ public class UriScoreCalculatorTest extends MongoDBScoreBasedTest {
 
     @Test
     public void testURIScore() throws URISyntaxException {
-        UriScoreCalculator uriScoreCalculator = new UriScoreCalculator(queryExecFactory);
+        UriDuplicityScoreCalculator uriScoreCalculator = new UriDuplicityScoreCalculator(queryExecFactory);
         float score1 = uriScoreCalculator.getURIScore(new CrawleableUri(new URI("http://dbpedia.org/resource/Berlin")));
         float score2 = uriScoreCalculator.getURIScore(new CrawleableUri(new URI("http://dbpedia.org/resource/Bangalore")));
         Assert.assertEquals(.1f, score1, .0001);

--- a/squirrel.mockup/src/main/java/org/dice_research/squirrel/simulation/ScenarioBasedTest.java
+++ b/squirrel.mockup/src/main/java/org/dice_research/squirrel/simulation/ScenarioBasedTest.java
@@ -1,14 +1,5 @@
 package org.dice_research.squirrel.simulation;
 
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Statement;
@@ -29,8 +20,13 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.dice_research.squirrel.simulation.AbstractServerMockUsingTest;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
 
 @RunWith(Parameterized.class)
 public class ScenarioBasedTest extends AbstractServerMockUsingTest {
@@ -128,11 +124,7 @@ public class ScenarioBasedTest extends AbstractServerMockUsingTest {
         // Serializer serializer = (Serializer) context.getBean("serializerBean");
         // UriCollector collector = (UriCollector) context.getBean("uriCollectorBean");
         Worker worker = (Worker) context.getBean("workerBean");
-
-        for (int i = 0; i < seeds.length; ++i) {
-            frontier.addNewUri(seeds[i]);
-        }
-
+        frontier.addNewUris(Arrays.asList(seeds));
         Thread t = new Thread(worker);
         t.start();
         do {

--- a/squirrel.worker/src/main/java/org/dice_research/squirrel/components/WorkerComponent.java
+++ b/squirrel.worker/src/main/java/org/dice_research/squirrel/components/WorkerComponent.java
@@ -164,12 +164,7 @@ public class WorkerComponent extends AbstractComponent implements Frontier {
     public void setWorker(Worker worker) {
         this.worker = worker;
     }
-
-    @Override
-    public void addNewUri(CrawleableUri uri) {
-        addNewUris(Collections.singletonList(uri));
-    }
-
+    
     @Override
     public void addNewUris(List<CrawleableUri> uris) {
         try {

--- a/squirrel.worker/src/main/java/org/dice_research/squirrel/components/WorkerComponent.java
+++ b/squirrel.worker/src/main/java/org/dice_research/squirrel/components/WorkerComponent.java
@@ -1,12 +1,5 @@
 package org.dice_research.squirrel.components;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.TimeUnit;
-
 import org.dice_research.squirrel.Constants;
 import org.dice_research.squirrel.data.uri.CrawleableUri;
 import org.dice_research.squirrel.data.uri.serialize.Serializer;
@@ -27,6 +20,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @Qualifier("workerComponent")
@@ -164,7 +163,7 @@ public class WorkerComponent extends AbstractComponent implements Frontier {
     public void setWorker(Worker worker) {
         this.worker = worker;
     }
-    
+
     @Override
     public void addNewUris(List<CrawleableUri> uris) {
         try {

--- a/squirrel.worker/src/test/java/org/dice_research/squirrel/fetcher/FetcherTest.java
+++ b/squirrel.worker/src/test/java/org/dice_research/squirrel/fetcher/FetcherTest.java
@@ -6,6 +6,9 @@ import org.dice_research.squirrel.queue.IpAddressBasedQueue;
 import org.dice_research.squirrel.sink.Sink;
 import org.dice_research.squirrel.sink.impl.mem.InMemorySink;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /*
  * TODO Has to be reworked or deleted
  */
@@ -17,7 +20,10 @@ public class FetcherTest {
         IpAddressBasedQueue queue = new InMemoryQueue();
         System.out.println(crawleableUri);
 
-        queue.addUri(crawleableUri);
+        List<CrawleableUri> urisToAdd = new ArrayList<>();
+        urisToAdd.add(crawleableUri);
+        queue.addUris(urisToAdd);
+
 //        Frontier frontier = new FrontierImpl(new InMemoryKnownUriFilter(-1), queue);
 //        Worker worker = new WorkerImpl(ZeroMQBasedFrontierClient.create(FRONTIER_ADDRESS, 0), sink,
 //                new RobotsManagerImpl(new SimpleHttpFetcher(new UserAgent("Test", "", ""))),


### PR DESCRIPTION
…) are used in all the queues.

1. UriQueue now only has addUris() method which adds the Uris key-wise.
2. Changes done in frontier to use addUris()
3. Other refactoring done according to PR #144 comments.